### PR TITLE
fix path when running Grist

### DIFF
--- a/run.js
+++ b/run.js
@@ -54,6 +54,7 @@ function startGrist() {
       ...process.env,
       PORT: process.env.GRIST_PORT,
     },
+    cwd: '/grist',
     stdio: 'inherit',
     detached: true,
   });


### PR DESCRIPTION
I think I broke the omnibus when I flattened the image for https://github.com/gristlabs/grist-omnibus/issues/2 since it lost some path information. Not sure why I didn't catch this in testing.