### PR TITLE
try adding a smoke test

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ex
+# Does a very simple smoke test to make sure Grist API is available
+# In .github directory just to avoid adding more files/directories
+# in root :-)
+
+IMAGE=gristlabs/grist-omnibus
+TEAM=cool-beans
+PORT=9998
+
+mkdir -p /tmp/omnibus-test
+docker run --rm --name grist \
+       -e URL=http://localhost:$PORT \
+       -v /tmp/omnibus-test:/persist \
+       -e EMAIL=owner@example.com \
+       -e PASSWORD=topsecret \
+       -e TEAM=$TEAM \
+       -p $PORT:80 \
+       -d $IMAGE
+
+function finish {
+  docker logs grist || echo no logs
+  docker kill grist > /dev/null
+}
+trap finish EXIT
+
+for ct in $(seq 1 20); do
+  echo "Check $ct"
+  check="$(curl http://localhost:$PORT/api/orgs || echo fail)"
+  if [[ "$check" = "[]" ]]; then
+    echo Grist is responsive
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Grist did not respond"
+exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,11 +24,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build grist-omnibus for testing
+        uses: docker/build-push-action@v2
+        with:
+          pull: true
+          load: true
+          tags: ${{ github.repository_owner }}/grist-omnibus:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Do a smoke test on grist-omnibus
+        run: make test
       - name: Push grist-omnibus to Docker Hub
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64,linux/arm64/v8
-          pull: true
           push: true
           tags: ${{ github.repository_owner }}/grist-omnibus:latest
           cache-from: type=gha

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ pushwitharch:
           --build-arg BASE=$(BASE) \
           -t $(IMAGE) --push .
 
+test:
+	./.github/test.sh
+
 makecert:
 	@echo "Put grist.example.com in your /etc/hosts as 127.0.0.1, and make a self-signed cert for it"
 	openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes


### PR DESCRIPTION
Add a small smoke test to make sure Grist is somewhat functional before updating the docker image. In future, it would be good to add a batch of automated tests, as `grist-core` itself has.