### PR TITLE
Strip out X-Forwarded-User header (or rather GRIST_FORWARD_AUTH_HEADER)

### DIFF
--- a/traefik.yaml
+++ b/traefik.yaml
@@ -29,64 +29,28 @@ http:
 
   routers:
     route-grist-login:
-      rule: "PathPrefix(`/auth/login`)"
+      rule: "PathPrefix(`/auth/login`) || PathPrefix(`/_oauth`)"
       service: grist
       middlewares:
         - tfa
       entryPoints:
         - web
-    route-grist-auth:
-      rule: "PathPrefix(`/_oauth`)"
-      service: grist
-      middlewares:
-        - tfa
-      entryPoints:
-        - web
+
     route-grist:
       rule: "PathPrefix(`/`)"
+      priority: 1   # Set a lower priority than the other rules
       service: grist
       middlewares:
         - no-fwd
       entryPoints:
         - web
-    route-signed-out:
-      rule: "Path(`/signed-out`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - web
-    route-api:
-      rule: "PathPrefix(`/api/`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - web
-    route-api-org:
-      rule: "PathPrefix(`/o/{org:[^/]+}/api/`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - web
-    route-assets:
-      rule: "PathPrefix(`/v/unknown/`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - web
+
     route-dex:
-      rule: "PathPrefix(`/dex/`)"
+      rule: "PathPrefix(`/dex/`) || Path(`/dex`)"
       service: dex
       entryPoints:
         - web
-    route-dex-bare:
-      rule: "Path(`/dex`)"
-      service: dex
-      entryPoints:
-        - web
+
     route-who:
       rule: "Path(`/who`)"
       service: whoami
@@ -96,73 +60,31 @@ http:
 {{ $use_https := env "USE_HTTPS" }}
 {{if eq $use_https "true" }}
     https-route-grist-login:
-      rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/auth/login`)"
+      rule: "Host(`{{ env "APP_HOST" }}`) && (PathPrefix(`/auth/login`) || PathPrefix(`/_oauth`))"
       service: grist
       middlewares:
         - tfa
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
-    https-route-grist-auth:
-      rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/_oauth`)"
-      service: grist
-      middlewares:
-        - tfa
-      entryPoints:
-        - websecure
-      tls: {{ env "TLS" }}
+
     https-route-grist:
       rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/`)"
+      priority: 1   # Set a lower priority than the other rules
       service: grist
       middlewares:
         - no-fwd
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
-    https-route-signed-out:
-      rule: "Host(`{{ env "APP_HOST" }}`) && Path(`/signed-out`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - websecure
-      tls: {{ env "TLS" }}
-    https-route-api:
-      rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/api/`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - websecure
-      tls: {{ env "TLS" }}
-    https-route-api-org:
-      rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/o/{org:[^/]+}/api/`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - websecure
-      tls: {{ env "TLS" }}
-    https-route-assets:
-      rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/v/unknown/`)"
-      service: grist
-      middlewares:
-        - no-fwd
-      entryPoints:
-        - websecure
-      tls: {{ env "TLS" }}
+
     https-route-dex:
-      rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/dex/`)"
+      rule: "Host(`{{ env "APP_HOST" }}`) && (PathPrefix(`/dex/`) || Path(`/dex`))"
       service: dex
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
-    https-route-dex-bare:
-      rule: "Host(`{{ env "APP_HOST" }}`) && Path(`/dex`)"
-      service: dex
-      entryPoints:
-        - websecure
-      tls: {{ env "TLS" }}
+
     https-route-who:
       rule: "Host(`{{ env "APP_HOST" }}`) && Path(`/who`)"
       service: whoami

--- a/traefik.yaml
+++ b/traefik.yaml
@@ -22,6 +22,10 @@ http:
       forwardauth:
         address: 'http://127.0.0.1:{{ env "TFA_PORT" }}'
         authResponseHeaders: [ '{{ env "GRIST_FORWARD_AUTH_HEADER" }}' ]
+    no-fwd:
+      headers:
+        customRequestHeaders:
+          '{{ env "GRIST_FORWARD_AUTH_HEADER" }}': ""
 
   routers:
     route-grist-login:
@@ -41,26 +45,36 @@ http:
     route-grist:
       rule: "PathPrefix(`/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - web
     route-signed-out:
       rule: "Path(`/signed-out`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - web
     route-api:
       rule: "PathPrefix(`/api/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - web
     route-api-org:
       rule: "PathPrefix(`/o/{org:[^/]+}/api/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - web
     route-assets:
       rule: "PathPrefix(`/v/unknown/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - web
     route-dex:
@@ -100,30 +114,40 @@ http:
     https-route-grist:
       rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
     https-route-signed-out:
       rule: "Host(`{{ env "APP_HOST" }}`) && Path(`/signed-out`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
     https-route-api:
       rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/api/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
     https-route-api-org:
       rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/o/{org:[^/]+}/api/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}
     https-route-assets:
       rule: "Host(`{{ env "APP_HOST" }}`) && PathPrefix(`/v/unknown/`)"
       service: grist
+      middlewares:
+        - no-fwd
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}


### PR DESCRIPTION
- For Grist endpoints other than those handled by `traefik-forward-auth` middleware, clear out the header used for auth. This is important since it's a header Grist is told to trust, so we should not trust it coming from the outside. For `traefik-forward-auth` middleware, it takes care of clearing the header before setting its own value.
- Simplify the config a bit, by combining routes/endpoints that differ only in path.