### PR TITLE
Enable gvisor by default; exit docker if any server fails; log more visibly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,12 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -a -
 # Extend Grist image.
 FROM $BASE as merge
 
+# Enable sandboxing by default. It is generally important when sharing with
+# others. You may override it, e.g. "unsandboxed" uses no sandboxing but is
+# only OK if you trust all users fully.
+ENV GRIST_SANDBOX_FLAVOR=gvisor
+ENV GVISOR_FLAGS="-unprivileged -ignore-cgroups"
+
 # apache2-utils is for htpasswd, used with dex
 RUN \
   apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ FROM $BASE as merge
 # others. You may override it, e.g. "unsandboxed" uses no sandboxing but is
 # only OK if you trust all users fully.
 ENV GRIST_SANDBOX_FLAVOR=gvisor
-ENV GVISOR_FLAGS="-unprivileged -ignore-cgroups"
 
 # apache2-utils is for htpasswd, used with dex
 RUN \

--- a/run.js
+++ b/run.js
@@ -130,7 +130,7 @@ function checkGvisor() {
     child_process.execSync(`runsc --network none ${flags} do true`, { encoding: 'utf-8' });
     console.log('gvisor ok');
   } catch (e) {
-    console.log('gvisor FAILED', e.message.trim().split('\n', 2).slice(0, 2).join('\n'));
+    console.log('gvisor FAILED');     // Stderr is already reported above, so don't repeat it.
     throw new Error("gvisor failed; consider a different GRIST_SANDBOX_FLAVOR");
   }
 }


### PR DESCRIPTION
Incidentally, pyodide is not available in `gristlabs/grist-omnibus` (or `gristlabs/grist`) docker images, so I did not include it as a recommended fallback.