### PR TITLE
When running behind another proxy, need to tell traefik to trust its X-Forwarded-* headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ docker run \
 Remember if you are on a public server you don't need to do this, you can
 set `HTTPS=auto` and have Traefik + Let's Encrypt do the work for you.
 
+If you run the omnibus behind a separate reverse proxy that terminates SSL, then you should
+`HTTPS=external`, and set an additional environment variable `TRUSTED_PROXY_IPS` to the IIP
+address or IP range of the proxy. This may be a comma-separated list, e.g.
+`127.0.0.1/32,192.168.1.7`. See Traefik's [forwarded
+headers](https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers).
+
 You can change `dex.yaml` (for example, to fill in keys for Google
 and Microsoft sign-ins, or to remove them) and then either rebuild
 the image or (easier) make the custom settings available to the omnibus

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Remember if you are on a public server you don't need to do this, you can
 set `HTTPS=auto` and have Traefik + Let's Encrypt do the work for you.
 
 If you run the omnibus behind a separate reverse proxy that terminates SSL, then you should
-`HTTPS=external`, and set an additional environment variable `TRUSTED_PROXY_IPS` to the IIP
+`HTTPS=external`, and set an additional environment variable `TRUSTED_PROXY_IPS` to the IP
 address or IP range of the proxy. This may be a comma-separated list, e.g.
 `127.0.0.1/32,192.168.1.7`. See Traefik's [forwarded
 headers](https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers).

--- a/run.js
+++ b/run.js
@@ -94,9 +94,14 @@ function startTraefik() {
   if (process.env.HTTPS) {
     flags.push("--entrypoints.websecure.address=:443")
   }
+  let TFA_TRUST_FORWARD_HEADER = 'false';
+  if (process.env.TRUSTED_PROXY_IPS) {
+    flags.push(`--entryPoints.web.forwardedHeaders.trustedIPs=${process.env.TRUSTED_PROXY_IPS}`)
+    TFA_TRUST_FORWARD_HEADER = 'true';
+  }
   log.info("Calling traefik", flags);
   essentialProcess("traefik", child_process.spawn('traefik', flags, {
-    env: process.env,
+    env: {...process.env, TFA_TRUST_FORWARD_HEADER},
     stdio: 'inherit',
     detached: true,
   }));

--- a/traefik.yaml
+++ b/traefik.yaml
@@ -22,6 +22,7 @@ http:
       forwardauth:
         address: 'http://127.0.0.1:{{ env "TFA_PORT" }}'
         authResponseHeaders: [ '{{ env "GRIST_FORWARD_AUTH_HEADER" }}' ]
+        trustForwardHeader: '{{ env "TFA_TRUST_FORWARD_HEADER" }}'
     no-fwd:
       headers:
         customRequestHeaders:


### PR DESCRIPTION
This addresses the issues described in #12.

When SSL is terminated externally, grist-omnibus receives requests via HTTP. In order for it to know that the end-user accessed it via HTTPS, the external reverse proxy should set X-Forwarded-* headers (only `X-Forwarded-Proto` matters here), and traefik in grist-omnibus needs to know to trust it.

The most secure way is to specify the IP address or range of the proxy, so that's the new environment variable being exposed.

In addition, `traefik-forward-auth` needs its own flag to trust the X-Forwarded-* headers, as it is the piece that constructs `redirect_uri` based on whether it thinks the end-user is using HTTP or HTTPS.