### PR TITLE
have traefik redirect http to https when https is available

### DIFF
--- a/run.js
+++ b/run.js
@@ -94,6 +94,7 @@ function startTraefik() {
   if (process.env.HTTPS) {
     flags.push("--entrypoints.websecure.address=:443")
     // Redirect http -> https
+    // See: https://doc.traefik.io/traefik/routing/entrypoints/#redirection
     flags.push("--entrypoints.web.http.redirections.entrypoint.scheme=https")
     flags.push("--entrypoints.web.http.redirections.entrypoint.to=websecure")
   }

--- a/run.js
+++ b/run.js
@@ -93,6 +93,9 @@ function startTraefik() {
   }
   if (process.env.HTTPS) {
     flags.push("--entrypoints.websecure.address=:443")
+    // Redirect http -> https
+    flags.push("--entrypoints.web.http.redirections.entrypoint.scheme=https")
+    flags.push("--entrypoints.web.http.redirections.entrypoint.to=websecure")
   }
   log.info("Calling traefik", flags);
   essentialProcess("traefik", child_process.spawn('traefik', flags, {


### PR DESCRIPTION
This configures traefik to redirect any plain http traffic to https if Grist is configured to listen for that. Could be made conditional on an environment variable, but it is hard to imagine a situation where this wouldn't be the desired behavior, so will wait for someone to ask for that.