### PR TITLE
Remove traefik-forward-auth in favour of built-in OIDC handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@
 ARG BASE=gristlabs/grist:latest
 
 # Gather main dependencies.
-FROM dexidp/dex:v2.33.1 as dex
-FROM traefik:2.8 as traefik
-FROM traefik/whoami as whoami
 
 # recent public traefik-forward-auth image doesn't support arm,
 # so build it from scratch.
@@ -27,9 +24,12 @@ ARG TARGETOS TARGETARCH
 RUN echo "Compiling for [$TARGETOS $TARGETARCH] (will be blank if not using BuildKit)"
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -a -installsuffix nocgo \
   -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
+FROM dexidp/dex:v2.33.1 AS dex
+FROM traefik:2.8 AS traefik
+FROM traefik/whoami AS whoami
 
 # Extend Grist image.
-FROM $BASE as merge
+FROM $BASE AS merge
 
 # Enable sandboxing by default. It is generally important when sharing with
 # others. You may override it, e.g. "unsandboxed" uses no sandboxing but is
@@ -75,6 +75,6 @@ RUN ln -s /custom/grist.crt /etc/ssl/certs/grist.pem
 # FROM scratch
 # COPY --from=merge / /
 
-CMD /grist/run.js
+CMD ["/grist/run.js"]
 
 EXPOSE 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,11 @@
 # Grist doesn't have a built-in login system, which can be
 # a stumbling block for beginners or people just wanting to
 # try it out.
-# Includes bundled traefik, traefik-forward-auth, and dex.
+# Includes bundled traefik and dex.
 
 ARG BASE=gristlabs/grist:latest
 
 # Gather main dependencies.
-
-# recent public traefik-forward-auth image doesn't support arm,
-# so build it from scratch.
-FROM golang:1.13-alpine as fwd
-RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth
-WORKDIR /go/src/github.com/thomseddon/traefik-forward-auth
-RUN apk add --no-cache git
-RUN mkdir -p /go/src/github.com/thomseddon/
-RUN cd /go/src/github.com/thomseddon/ && \
-  git clone https://github.com/thomseddon/traefik-forward-auth.git && \
-  cd traefik-forward-auth && \
-  git checkout c4317b7503fb0528d002eb1e5ee43c4a37f055d0
-ARG TARGETOS TARGETARCH
-RUN echo "Compiling for [$TARGETOS $TARGETARCH] (will be blank if not using BuildKit)"
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -a -installsuffix nocgo \
-  -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
 FROM dexidp/dex:v2.33.1 AS dex
 FROM traefik:2.8 AS traefik
 FROM traefik/whoami AS whoami
@@ -43,9 +27,6 @@ RUN \
   apt-get install -y --no-install-recommends ca-certificates tzdata && \
   rm -rf /var/lib/apt/lists/*
 
-# Copy in traefik-forward-auth program.
-COPY --from=fwd /traefik-forward-auth /usr/local/bin
-
 # Copy in traeefik program.
 COPY --from=traefik /usr/local/bin/traefik /usr/local/bin/traefik
 
@@ -64,10 +45,6 @@ COPY --from=whoami /whoami /usr/local/bin/whoami
 COPY dex.yaml /settings/dex.yaml
 COPY traefik.yaml /settings/traefik.yaml
 COPY run.js /grist/run.js
-
-# Make traefik-forward-auth trust self-signed certificates internally, if user
-# chooses to use one.
-RUN ln -s /custom/grist.crt /etc/ssl/certs/grist.pem
 
 # Squashing this way loses environment variables set in base image
 # so we need to revert it for now.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PORT = 8484
+PORT = 9999
 TEAM = cool-beans
 
 # Possible bases: gristlabs/grist, or gristlabs/grist-ee

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ It bundles:
    Microsoft, etc, and also (somewhat reluctantly) supports
    hard-coded user/passwords that can be handy for a quick
    fuss-free test.
- * An authentication middleware, [traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth) to
-   connect Grist and Dex via Traefik.
 
 Here's the minimal configuration you need to provide.
  * `EMAIL`: an email address, used for Let's Encrypt and for

--- a/dex.yaml
+++ b/dex.yaml
@@ -17,11 +17,11 @@ frontend:
   logoURL: '{{ getenv "APP_HOME_URL" }}/v/unknown/ui-icons/Logo/GristLogo.svg'
 
 staticClients:
-- id: '{{ getenv "PROVIDERS_OIDC_CLIENT_ID" }}'
+- id: '{{ getenv "GRIST_OIDC_IDP_CLIENT_ID" }}'
   redirectURIs:
-  - '{{ getenv "APP_HOME_URL" }}/_oauth'
+  - '{{ getenv "APP_HOME_URL" }}/oauth2/callback'
   name: 'Grist'
-  secret: '{{ getenv "PROVIDERS_OIDC_CLIENT_SECRET" }}'
+  secret: '{{ getenv "GRIST_OIDC_IDP_CLIENT_SECRET" }}'
 
 
 oauth2:

--- a/run.js
+++ b/run.js
@@ -109,17 +109,6 @@ function startDex() {
   }));
 }
 
-function startTfa() {
-  log.info('Starting traefik-forward-auth');
-  essentialProcess("traefik-forward-auth", child_process.spawn('traefik-forward-auth', [
-    `--port=${process.env.TFA_PORT}`
-  ], {
-    env: process.env,
-    stdio: 'inherit',
-    detached: true,
-  }));
-}
-
 function startWho() {
   child_process.spawn('whoami', {
     env: {

--- a/run.js
+++ b/run.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const child_process = require('child_process');
 const colors = require('colors/safe');
-const commander = require('commander');
 const fetch = require('node-fetch');
 const https = require('https');
 const path = require('path');
@@ -20,38 +19,22 @@ const log = {
 
 
 async function main() {
-  const {program} = commander;
-  program.option('-p, --part <part>');
-  program.parse();
-  const options = program.opts();
-  const part = options.part || 'all';
-
   prepareDirectories();
   prepareMainSettings();
   prepareNetworkSettings();
   prepareCertificateSettings();
-  if (part === 'grist' || part === 'all') {
-    startGrist();
-  }
-  if (part === 'traefik' || part === 'all') {
-    startTraefik();
-  }
-  if (part === 'who' || part === 'all') {
-    startWho();
-  }
-  if (part === 'dex' || part === 'all') {
-    startDex();
-  }
-  if (part === 'tfa' || part === 'all') {
-    await waitForDex();
-    startTfa();
-  }
+
+  startGrist();
+  startTraefik();
+  startWho();
+  startDex();
+  await waitForDex();
+  startTfa();
+
   await sleep(1000);
   log.info('I think everything has started up now');
-  if (part === 'all') {
-    const ports = process.env.HTTPS ? '80/443' : '80';
-    log.info(`Listening internally on ${ports}, externally at ${process.env.URL}`);
-  }
+  const ports = process.env.HTTPS ? '80/443' : '80';
+  log.info(`Listening internally on ${ports}, externally at ${process.env.URL}`);
 }
 
 main().catch(e => log.error(e));

--- a/run.js
+++ b/run.js
@@ -3,8 +3,6 @@
 const fs = require('fs');
 const child_process = require('child_process');
 const colors = require('colors/safe');
-const fetch = require('node-fetch');
-const https = require('https');
 const path = require('path');
 
 function consoleLogger(level, color) {
@@ -253,38 +251,6 @@ function addDexUsers() {
   }
   deactivate();
   return txt.join('\n') + '\n';
-}
-
-async function waitForDex() {
-  const fetchOptions = process.env.HTTPS ? {
-    agent: new https.Agent({
-      // If we are responsible for certs, wait for them to be
-      // set up and valid - don't accept default self-signed
-      // traefik certs. Otherwise traefik-forward-auth will
-      // fail immediately if it sees a self-signed cert, without
-      // giving letsencrypt time to make one for us.
-      //
-      // Otherwise, don't fret, the responsibility for certs
-      // being in place before the rest of grist-omnibus starts
-      // lies elsewhere. We only care if dex is up and running.
-      rejectUnauthorized: (process.env.HTTPS === 'auto'),
-    })
-  } : {};
-  let delay = 0.1;
-  while (true) {
-    const url = process.env.PROVIDERS_OIDC_ISSUER_URL + '/.well-known/openid-configuration';
-    log.info(`Checking dex... at ${url}`);
-    try {
-      const result = await fetch(url, fetchOptions);
-      log.debug(`  got: ${result.status}`);
-      if (result.status === 200) { break; }
-    } catch (e) {
-      log.debug(`  not ready: ${e}`);
-    }
-    await sleep(1000 * delay);
-    delay = Math.min(5.0, delay * 1.2);
-  }
-  log.info("Happy with dex");
 }
 
 function sleep(ms) {

--- a/run.js
+++ b/run.js
@@ -28,8 +28,6 @@ async function main() {
   startTraefik();
   startWho();
   startDex();
-  await waitForDex();
-  startTfa();
 
   await sleep(1000);
   log.info('I think everything has started up now');
@@ -205,12 +203,13 @@ function prepareNetworkSettings() {
   process.env.TFA_PORT = `${alt}7101`;
   process.env.WHOAMI_PORT = `${alt}7102`;
 
-  setBrittleEnv('DEFAULT_PROVIDER', 'oidc');
-  process.env.PROVIDERS_OIDC_CLIENT_ID = invent('PROVIDERS_OIDC_CLIENT_ID');
-  process.env.PROVIDERS_OIDC_CLIENT_SECRET = invent('PROVIDERS_OIDC_CLIENT_SECRET');
-  process.env.PROVIDERS_OIDC_ISSUER_URL = `${process.env.APP_HOME_URL}/dex`;
-  process.env.SECRET = invent('TFA_SECRET');
-  process.env.LOGOUT_REDIRECT = `${process.env.APP_HOME_URL}/signed-out`;
+  // Setup OIDC
+  process.env.GRIST_OIDC_SP_HOST = process.env.APP_HOME_URL;
+  process.env.GRIST_OIDC_IDP_ISSUER = `${process.env.APP_HOME_URL}/dex`;
+  process.env.GRIST_OIDC_IDP_CLIENT_ID = invent('GRIST_OIDC_IDP_CLIENT_ID');
+  process.env.GRIST_OIDC_IDP_CLIENT_SECRET = invent('GRIST_OIDC_IDP_CLIENT_SECRET');
+  process.env.GRIST_OIDC_IDP_END_SESSION_ENDPOINT = `${process.env.APP_HOME_URL}/signed-out`;
+
 }
 
 function setSynonym(name1, name2) {

--- a/traefik.yaml
+++ b/traefik.yaml
@@ -8,21 +8,12 @@ http:
       loadBalancer:
         servers:
           - url: 'http://127.0.0.1:{{ env "DEX_PORT" }}'
-    tfa:
-      loadBalancer:
-        servers:
-          - url: 'http://127.0.0.1:{{ env "TFA_PORT" }}'
     whoami:
       loadBalancer:
         servers:
           - url: 'http://127.0.0.1:{{ env "WHOAMI_PORT" }}'
 
   middlewares:
-    tfa:
-      forwardauth:
-        address: 'http://127.0.0.1:{{ env "TFA_PORT" }}'
-        authResponseHeaders: [ '{{ env "GRIST_FORWARD_AUTH_HEADER" }}' ]
-        trustForwardHeader: '{{ env "TFA_TRUST_FORWARD_HEADER" }}'
     no-fwd:
       headers:
         customRequestHeaders:
@@ -32,8 +23,6 @@ http:
     route-grist-login:
       rule: "PathPrefix(`/auth/login`) || PathPrefix(`/_oauth`)"
       service: grist
-      middlewares:
-        - tfa
       entryPoints:
         - web
 
@@ -63,8 +52,6 @@ http:
     https-route-grist-login:
       rule: "Host(`{{ env "APP_HOST" }}`) && (PathPrefix(`/auth/login`) || PathPrefix(`/_oauth`))"
       service: grist
-      middlewares:
-        - tfa
       entryPoints:
         - websecure
       tls: {{ env "TLS" }}


### PR DESCRIPTION
Closes: #18 

Original commit messages:

* 5bbc2718a02e run: remove argument parsing

  We never actually call `run.js` with any CLI args, so let's just
  simplify this part of the code. This seems like leftover debug code.

* c1b84226f32c Dockerfile: linting

  Need to match keyword casing and pass CMD args via JSON.

* f45d710e32ad prepareNetworkSettings: replace traeffik-forward-auth with built-in OIDC

  This necessitates changing some envvars around and changing their
  names in the dex config. Naturally the middleware also has to be
  removed from traeffik.

* dfa1bcef26c0 run: remove residual env vars

  There was a lot of env var shuffling around required for
  traeffik-forward-auth. That can be removed now.

* 95bc26d8063d startTfa: remove this function

  We already removed its only calling site.

* 75797476bfd3 waitForDex: remove this function

  It was only needed for traeffik-forward-auth, safe to remove now.

* c36db5f1304d Dockerfile: remove installation of traeffik-forward-auth

  We just removed its use, so we don't need it in our Dockerfile either.

* dc51c9fa3747 README: remove mention of traeffik-forward-auth

  It's completely gone from the code.

