### PR TITLE
run: grab the Dex port from the URL

### DIFF
--- a/run.js
+++ b/run.js
@@ -155,7 +155,7 @@ function prepareMainSettings() {
 function prepareNetworkSettings() {
   const url = new URL(process.env.URL);
   process.env.APP_HOST = url.hostname || 'localhost';
-  process.env.DEX_PORT = '9999';
+  process.env.DEX_PORT = url.port || '9999';
 
   // Keep other ports out of the way of Dex port.
   const alt = String(process.env.DEX_PORT).charAt(0) === '1' ? '2' : '1';


### PR DESCRIPTION
I think that now that we no longer have the treafik-forward-auth proxy, the Dex port should match the external port, as it's now being access directly.