### PR TITLE
chore: bump dex version to 2.44.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 ARG BASE=gristlabs/grist:latest
 
 # Gather main dependencies.
-FROM dexidp/dex:v2.33.1 AS dex
+FROM dexidp/dex:v2.44.0 AS dex
 FROM traefik:2.8 AS traefik
 FROM traefik/whoami AS whoami
 


### PR DESCRIPTION
## chore: bump dex version to 2.44.0

Updates the dex version in the Dockerfile from 2.33.0 to 2.44.0.

### Why this change

- Includes fix for CVE with 9.3 CVSS score ([v2.35.0](https://github.com/dexidp/dex/releases/tag/v2.35.0))
- No breaking changes detected in the changelog
- Tested in production deployment, runs perfectly fine since 14 days
- Also tested with a fresh omnibus install and a keycloak vm as idp

### Notes for users

- [v2.39.0](https://github.com/dexidp/dex/releases/tag/v2.39.0) introduced stricter LDAP connector validation — users relying on LDAP for authentication should review their configuration
- [v2.40.0 ](https://github.com/dexidp/dex/releases/tag/v2.40.0)changed logging format, but this should not impact functionality